### PR TITLE
Quick & Dirty fix for #1: Ignore resubmissions and cross-listings

### DIFF
--- a/scan_astroph/scan_astroph.py
+++ b/scan_astroph/scan_astroph.py
@@ -9,7 +9,7 @@ ARXIV_BASE = 'https://arxiv.org/list/astro-ph.EP'
 DEBUG = False
 
 REGEX = \
-r'''<dt><a name="item(\d+)">.*<span class="list-identifier"><a href="/abs/([0-9.]*)".*</span></dt>
+r'''<dt><a name="item(\d+)">.*<span class="list-identifier"><a href="/abs/([0-9.]*)".*<\/a> (?!\(replaced)(?!\(cross-list).*</span></dt>
 <dd>
 <div class="meta">
 <div class="list\-title mathjax">\s*


### PR DESCRIPTION
This ignores all resubmissions and cross-listings by negating all regex matches with `(replaced` or `(cross-list` in the first line of the listing.

This is the quick & dirty way of fixing this, eventually #6 will superseed this solution, but this works for now.

Fixes #1