### PR TITLE
Implementation of new config-file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,39 +19,80 @@ python3 -m pip install --upgrade git+https://github.com/matiscke/scan_astro-ph.g
 ```
 
 # Usage
-
-## Set up keywords and relevant authors
-### either manually:
-- In your current working directory, create the files `authors.txt` and `keywords.txt`.
-- write down your favorite authors and keywords, plus a ranking for each. I suggest integers ranging from 1 to 5, where 5 is most relevant. The *syntax* is just like for a *python dictionary*.
-
-Example `authors.txt`:
-```
-{"Alpher" : 1, "Bethe" : 2, "Gamov" : 3}
-```
-Example `keywords.txt`:
-```
-{"star": 1, "planet": 2, "habitable": 3}
-```
-
-### or let `scan_astro-ph` do it for you:
-- Run `scan_astro-ph.wordcounter` (or `python -m scan_astroph.wordcounter`).
-It will ask for an ASCII file and extract words with 4-12 characters from it, sorted by occurrence in the file.
-- You will be asked to rank these suggested keywords. For each word shown, press 'Enter' to reject it or provide an integer rating, e.g., from 1 to 5 (higher=more relevant). Conclude by pressing `C`.
-- Manually insert particularly important authors and their ratings in `authors.txt` (currently, the automated search works only for keywords).
-
-
 ## Query today's astro-ph listing for relevant papers
-Just run `scan_astro-ph` (or `python -m scan_astroph`).
+First setup your keywords and authors (see configuration section),
+then just run `scan_astro-ph` (or `python -m scan_astroph`) to get the relevant listings.
 
-## Options
+## Command line reference
 ```
-'-d', '--date': date in format yyyy-mm, or "new", or "recent"', default=None
-'-l', '--len': length of result list, all is -1, default=-1
-'-v', '--rating': minimum rating for result list, default=6
-'--reverse': reverse list (lowest ranked paper on top)
-'--debug': debug mode, default=False
+usage: scan_astro-ph [-h] [--config /path/to/config] [--default-config [/path/to/config]] [--config-convert [/path/to/config]] [--edit] [-d DATE] [-l LENGTH] [-v RATING] [--reverse] [--show-resubmissions] [--ignore-cross-lists] [--log {info,debug}] [--version]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --config /path/to/config
+                        Path to configuration file (check README for defaults)
+  --default-config [/path/to/config]
+                        Write default config to default location (or specified path)
+  --config-convert [/path/to/config]
+                        Convert authors and keywords config from legacy format
+  --edit                Edit config in default text editor
+  -d DATE, --date DATE  date in format yyyy-mm, or "new", or "recent"
+  -l LENGTH, --len LENGTH
+                        length of result list, all is -1
+  -v RATING, --rating RATING
+                        minimum rating for result list
+  --reverse             reverse list (lowest ranked paper on top)
+  --show-resubmissions  Include resubmissions
+  --ignore-cross-lists  Include cross-lists
+  --log {info,debug}    Set loglevel
+  --version             show program's version number and exit
 ```
+# Configuration
+In the configuration file all the keywords and authors have to be set, as well as other optional configuration.
+
+The easiest way to get started is to run `scan_astro-ph --edit`, this will open the configuration file in the
+default text editor.
+
+Alternatively create a default configfile with `scan_astro-ph --default-config`, and edit it manually.
+
+## Configuration format:
+```ini
+[authors]
+# author = rating
+Alpher = 1
+Bethe = 2
+Gamov = 3
+
+[keywords]
+# keyword = rating
+star = 1
+planet = 2
+habitable = 3
+
+[options]
+# other optional options (can also be set on CLI)
+date = new
+length = -1
+minimum_rating = 6
+reverse_list = False
+show_resubmissions = False
+show_cross_lists = True
+```
+
+## Automatically find keywords with `scan_astro-ph.wordcounter`:
+- Run `scan_astro-ph.wordcounter file_to_scan` (or `python -m scan_astroph.wordcounter file_to_scan`).
+It scan the text file and extract words with 4-12 characters from it, sorted by occurrence in the file.
+- You will be asked to rank these suggested keywords. For each word shown, press 'Enter' to reject it or provide an integer rating, e.g., from 1 to 5 (higher=more relevant). Conclude by pressing `C`.
+- Manually insert particularly important authors into the config file (e.g. with `scan_astro-ph --edit`)
+
+## Configuration locations:
+`scan_astro-ph` searches the these paths for the config file, and loads the first found:
+- from environment variable: `$SCAN_ASTRO_PH_CONF`
+- from home directory: `~/.scan_astroph.conf`
+- default path (platform dependent):
+  - on Linux / Unix (except MacOS): `$XDG_CONFIG_HOME/scan_astroph/scan_astroph.conf` (`XDG_CONFIG_HOME` defaults to `~/.config`)
+  - on MacOS: `~/Library/Application Support/scan_astroph/scan_astroph.conf`
+  - on Windows: `$HOME/Documents/scan_astroph/scan_astroph.conf`
 
 # Feedback
 All feedback, including bug reports, feature requests, pull requests, etc., is welcome. `scan_astro-ph` is being actively developed in an open repository; if you have any trouble please raise an [issue](https://github.com/matiscke/scan_astro-ph/issues/new).

--- a/scan_astroph/__main__.py
+++ b/scan_astroph/__main__.py
@@ -1,14 +1,15 @@
 import logging
-from argparse import ArgumentParser
 import sys
+from argparse import ArgumentParser
+from pathlib import Path
 
 from . import __version__
-from .config import Config, find_configfile, load_config_legacy_format
+from .config import (Config, configfile_default_location, find_configfile,
+                     load_config_legacy_format)
 from .entry_evaluation import evaluate_entries, sort_entries
 from .output import print_entries
 from .parse import parse_html
 from .tools import load_html
-from pathlib import Path
 
 ARXIV_BASE = 'https://arxiv.org/list/astro-ph.EP'
 
@@ -50,7 +51,7 @@ def main():
     # write default config
     if args.default_config:
         if args.default_config is True:
-            path = Path.home() / ".scan_astro-ph.conf"
+            path = configfile_default_location(mkdir=True)
         else:
             path = args.default_config
         config = Config()
@@ -58,10 +59,10 @@ def main():
         print("Written default config to {}".format(path))
         sys.exit()
 
-    # convert config into new format
+    # convert legacy config into new format
     if args.config_convert:
         if args.config_convert is True:
-            path = Path.home() / ".scan_astro-ph.conf"
+            path = configfile_default_location(mkdir=True)
         else:
             path = args.config_convert
         config = load_config_legacy_format("keywords.txt", "authors.txt")

--- a/scan_astroph/__main__.py
+++ b/scan_astroph/__main__.py
@@ -31,7 +31,7 @@ def parse_cli_arguments() -> tuple:
                         help="length of result list, all is -1")
     parser.add_argument("-v", "--rating", type=int, default=None,
                         help="minimum rating for result list")
-    parser.add_argument("--reverse", action="store_false", default=None,
+    parser.add_argument("--reverse", action="store_true", default=None,
                         help="reverse list (lowest ranked paper on top)")
     parser.add_argument("--show-resubmissions", action="store_true", default=None,
                         help="Include resubmissions")

--- a/scan_astroph/__main__.py
+++ b/scan_astroph/__main__.py
@@ -4,8 +4,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from . import __version__
-from .config import (Config, configfile_default_location, find_configfile,
-                     load_config_legacy_format)
+from .config import (Config, configfile_default_location, file_editor,
+                     find_configfile, load_config_legacy_format)
 from .entry_evaluation import evaluate_entries, sort_entries
 from .output import print_entries
 from .parse import parse_html
@@ -23,6 +23,8 @@ def parse_cli_arguments() -> tuple:
                         help="Write default config to default location (or specified path)")
     parser.add_argument("--config-convert", nargs="?", default=False, const=True, metavar="/path/to/config",
                         help="Convert authors and keywords config from legacy format")
+    parser.add_argument("--edit", action="store_true",
+                        help="Edit config in default text editor")
     parser.add_argument("-d", "--date", default=None,
                         help='date in format yyyy-mm, or "new", or "recent"')
     parser.add_argument("-l", "--len", dest="length", type=int, default=None,
@@ -69,6 +71,19 @@ def main():
         config.write(path)
         print("Convert legacy configuration to {}".format(path))
         sys.exit()
+
+    # Open config file in text editor
+    if args.edit:
+        try:
+            path = find_configfile()
+        except FileNotFoundError:
+            if input("No config file found. Create at default location? [y/N] ").lower() == "y":
+                path = configfile_default_location(mkdir=True)
+                Config().write(path)
+            else:
+                print("No file to edit. Exiting")
+                sys.exit(1)
+        file_editor(path)
 
     # read config
     config = Config()

--- a/scan_astroph/config.py
+++ b/scan_astroph/config.py
@@ -74,10 +74,10 @@ class Config:
             self._config["options"][key] = str(value)
 
 
-def find_configfile():
+def find_configfile() -> Path:
     """Finds location of configuration file"""
     # Check environment variable
-    if "SCAN_ASTRO_PH_CONF" in os.environ:
+    if "SCAN_ASTROPH_CONF" in os.environ:
         return Path(os.path.expandvars(os.environ["SCAN_ASTRO_PH_CONF"]))
 
     # check home directory
@@ -85,16 +85,35 @@ def find_configfile():
     if configpath.is_file():
         return configpath
 
-    # CHECK $XDG_CONFIG_HOME
-    if "XDG_CONFIG_HOME" in os.environ:
-        configpath = Path(os.environ["XDG_CONFIG_HOME"]) / "scan_astro-ph.conf"
-    else:
-        configpath = Path.home() / ".config" / "scan_astro-ph.conf"
+    # check platform specific configuration location
+    configpath = configfile_default_location()
     if configpath.is_file():
         return configpath
-    else:
-        raise FileNotFoundError("Cannot find configuration file")
 
+    raise FileNotFoundError("Could not find scan_astroph.conf. Check Readme for config locations")
+
+def configfile_default_location(mkdir: bool=False) -> Path:
+    """Find platform dependent configfile location
+
+    With `mkdir=True` all parent directories for the config file are created.
+
+    On Linux: `$XDG_CONFIG_HOME/scan_astroph/scan_astroph.conf` (`~/.local/scan_astroph/scan_astroph.conf`)
+    On Windows: `$HOME/Documents/scan_astroph/scan_astroph.conf`
+    On MacOS: `$HOME/Library/Application Support/scan_astroph/scan_astroph.conf`
+
+    For more details check out documentation of appdirs
+    """
+    if sys.platform == "darwin": # MacOS
+        path = Path.home() / "Library" / "Application Support" / "scan_astroph" / "scan_astroph.conf"
+    elif sys.platform == "win32": # Windows
+        path = Path.home() / "Documents" / "scan_astroph" / "scan_astroph.conf"
+    else: # Linux and other Unixes
+        path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "scan_astroph" / "scan_astroph.conf"
+
+    if mkdir:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    return path
 
 def load_config_legacy_format(keywords_path: Path, authors_path: Path) -> Config:
     """Load config from legacy format (seperate JSON files for keywords and authors"""

--- a/scan_astroph/config.py
+++ b/scan_astroph/config.py
@@ -1,12 +1,87 @@
 """Read configuration files"""
 
 import json
+import os
+from configparser import ConfigParser
+from pathlib import Path
 
 
-def read_keywords(filename='keywords.txt'):
-    with open(filename) as json_file:
-        keywords = json.load(json_file)
-    return keywords
+class Config:
+    """configparser.ConfigParser wrapper with type conversion
 
-TITLE_KEYWORDS = read_keywords()
-AUTHORS = read_keywords('authors.txt')
+    Internally stores the configuration in a configparser.Configparser object,
+    but adds method for accessing keywords and authors with the right types, as
+    configparser only uses `str`
+    """
+
+    def __init__(self):
+        self._config = ConfigParser()
+
+        self._config["keywords"] = {}
+        self._config["authors"] = {}
+
+    @property
+    def keywords(self) -> dict:
+        """Get keywords/rating as dict with type `dict[str,int]`"""
+        return {keyword: int(rating) for keyword, rating in self._config["keywords"].items()}
+
+    def add_keyword(self, keyword: str, rating: int):
+        """Add keyword with rating to config"""
+        self._config["keywords"][keyword] = str(rating)
+
+    @property
+    def authors(self):
+        """Get authors/rating as dict with type `dict[str,int]`"""
+        return {author: int(rating) for author, rating in self._config["authors"].items()}
+
+    def add_author(self, author: str, rating: int):
+        """Add author with rating to config"""
+        self._config["authors"][author] = str(rating)
+
+    def read(self, path: Path):
+        """Read path to config. Existing values will be overwritten"""
+        self._config.read(path)
+
+    def write(self, path: Path, overwrite: bool = False):
+        """Write config to file. Will not overwrite existing files if `overwrite` is false"""
+        with open(path, "w" if overwrite else "x") as f:
+            self._config.write(f)
+
+
+def find_configfile():
+    """Finds location of configuration file"""
+    # Check environment variable
+    if "SCAN_ASTRO_PH_CONF" in os.environ:
+        return Path(os.path.expandvars(os.environ["SCAN_ASTRO_PH_CONF"]))
+
+    # check home directory
+    configpath = Path.home() / ".scan_astro-ph.conf"
+    if configpath.is_file():
+        return configpath
+
+    # CHECK $XDG_CONFIG_HOME
+    if "XDG_CONFIG_HOME" in os.environ:
+        configpath = Path(os.environ["XDG_CONFIG_HOME"]) / "scan_astro-ph.conf"
+    else:
+        configpath = Path.home() / ".config" / "scan_astro-ph.conf"
+    if configpath.is_file():
+        return configpath
+    else:
+        raise FileNotFoundError("Cannot find configuration file")
+
+
+def load_config_legacy_format(keywords_path: Path, authors_path: Path) -> Config:
+    """Load config from legacy format (seperate JSON files for keywords and authors"""
+    config = Config()
+
+    with open(keywords_path) as f:
+        keywords = json.load(f)
+    for keyword, rating in keywords.items():
+        config.add_keyword(keyword, rating)
+
+    with open(authors_path) as f:
+        authors = json.load(f)
+    for author, rating in authors.items():
+        config.add_author(author, rating)
+
+    return config

--- a/scan_astroph/config.py
+++ b/scan_astroph/config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from ast import literal_eval
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -19,11 +20,21 @@ class Config:
 
         self._config["keywords"] = {}
         self._config["authors"] = {}
+        self._config["options"] = {
+            "date": "new",
+            "length": -1,
+            "minimum_rating": 6,
+            "reverse_list": False,
+            "show_resubmissions": False,
+            "show_cross_lists": True,
+        }
 
     @property
     def keywords(self) -> dict:
         """Get keywords/rating as dict with type `dict[str,int]`"""
-        return {keyword: int(rating) for keyword, rating in self._config["keywords"].items()}
+        return {
+            keyword: int(rating) for keyword, rating in self._config["keywords"].items()
+        }
 
     def add_keyword(self, keyword: str, rating: int):
         """Add keyword with rating to config"""
@@ -32,7 +43,9 @@ class Config:
     @property
     def authors(self):
         """Get authors/rating as dict with type `dict[str,int]`"""
-        return {author: int(rating) for author, rating in self._config["authors"].items()}
+        return {
+            author: int(rating) for author, rating in self._config["authors"].items()
+        }
 
     def add_author(self, author: str, rating: int):
         """Add author with rating to config"""
@@ -46,6 +59,19 @@ class Config:
         """Write config to file. Will not overwrite existing files if `overwrite` is false"""
         with open(path, "w" if overwrite else "x") as f:
             self._config.write(f)
+
+    def __getitem__(self, key: str):
+        """Get option value from config"""
+        # use literal_eval to convert if its not a str
+        try:
+            return literal_eval(self._config["options"][key])
+        except ValueError:
+            return self._config["options"][key]
+
+    def __setitem__(self, key, value):
+        """Set option if value is not None"""
+        if value is not None:
+            self._config["options"][key] = str(value)
 
 
 def find_configfile():

--- a/scan_astroph/config.py
+++ b/scan_astroph/config.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import subprocess
+import sys
 from ast import literal_eval
 from configparser import ConfigParser
 from pathlib import Path
@@ -114,6 +116,22 @@ def configfile_default_location(mkdir: bool=False) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
 
     return path
+
+
+def file_editor(path: Path):
+    """Open file in default text editor
+
+    Opens in first editor set in environment variables $VISUAL or $EDITOR,
+    otherwise defaults to `vi` on unixes and Notepad on Windows.
+    """
+    if "VISUAL" in os.environ:
+        subprocess.run((os.environ["VISUAL"], path))
+    elif "EDITOR" in os.environ:
+        subprocess.run((os.environ["EDITOR"], path))
+    elif sys.platform == "win32":
+        subprocess.run(["notepad.exe", path])
+    else:
+        subprocess.run(("vi", path))
 
 def load_config_legacy_format(keywords_path: Path, authors_path: Path) -> Config:
     """Load config from legacy format (seperate JSON files for keywords and authors"""

--- a/scan_astroph/entry_evaluation.py
+++ b/scan_astroph/entry_evaluation.py
@@ -1,5 +1,6 @@
 """Definition of class Entry and all evaluation related functions"""
 import re
+import numpy as np
 
 
 class Entry(object):
@@ -68,11 +69,10 @@ def evaluate_entries(entries: list, keyword_ratings: dict, author_ratings: dict)
 def sort_entries(entries: list, rating_min: int, reverse: bool, length: int) -> list:
     ''' Sort entries by rating
 
-    Only entries with rating >= rating_min are
-    listed, and the list is at maximum length
-    entries long.
-    If reverse is True, the entries are reversed
-    (after cutting the list to length entries).
+    Only entries with rating >= rating_min are listed, and the list is at
+    maximum length entries long. If reverse is True, the entries are reversed
+    (after cutting the list to length entries). Note that the default order
+    is most relevant paper on top.
     '''
     if length < 0:
         length = None
@@ -80,6 +80,6 @@ def sort_entries(entries: list, rating_min: int, reverse: bool, length: int) -> 
     # remove entries with low rating
     entries_filtered = filter(lambda entry: entry.rating >= rating_min, entries)
     # sort by rating
-    results = sorted(entries_filtered, key=lambda x: x.rating, reverse=reverse)
+    results = sorted(entries_filtered, key=lambda x: x.rating, reverse=np.invert(reverse))
 
     return results[:length]

--- a/scan_astroph/entry_evaluation.py
+++ b/scan_astroph/entry_evaluation.py
@@ -1,6 +1,5 @@
 """Definition of class Entry and all evaluation related functions"""
 import re
-import numpy as np
 
 
 class Entry(object):
@@ -80,6 +79,6 @@ def sort_entries(entries: list, rating_min: int, reverse: bool, length: int) -> 
     # remove entries with low rating
     entries_filtered = filter(lambda entry: entry.rating >= rating_min, entries)
     # sort by rating
-    results = sorted(entries_filtered, key=lambda x: x.rating, reverse=np.invert(reverse))
+    results = sorted(entries_filtered, key=lambda x: x.rating, reverse=not reverse)
 
     return results[:length]

--- a/scan_astroph/wordcounter.py
+++ b/scan_astroph/wordcounter.py
@@ -5,7 +5,7 @@ from re import findall
 import argparse
 from pathlib import Path
 
-from .config import Config, find_configfile
+from .config import Config, find_configfile, configfile_default_location
 
 
 def _count_words(fname):
@@ -70,7 +70,7 @@ def main():
         try:
             configfile = find_configfile()
         except FileNotFoundError:
-            configfile = Path.home() / ".scan_astro-ph.conf"
+            configfile = configfile_default_location(mkdir=True)
     try:
         config.read(configfile)
     except FileNotFoundError:

--- a/scan_astroph/wordcounter.py
+++ b/scan_astroph/wordcounter.py
@@ -2,8 +2,10 @@ import json
 import os.path
 from collections import Counter
 from re import findall
+import argparse
+from pathlib import Path
 
-from . import config
+from .config import Config, find_configfile
 
 
 def _count_words(fname):
@@ -21,23 +23,19 @@ def most_common_words_in_file(fname, n, verbose=False):
     return counts
 
 
-def select_keywords(counts):
+def select_keywords(config: Config, counts):
     """Let the user rate or reject keywords"""
     # sort list by decreasing number of occurrence
     counts = dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
 
     print('for each suggested keyword, give a rating from 1 to 5 or reject it by pressing "enter".\nConclude by pressing "C".')
 
-    if os.path.exists('keywords.txt'):
-        # don't ask for previously added words
-        selected = config.read_keywords('keywords.txt')
-        for key in selected:
-            try:
-                counts.pop(key)
-            except KeyError:
-                pass
-    else:
-        selected = {}
+    # don't ask for previously added words
+    for key in config.keywords:
+        try:
+            counts.pop(key)
+        except KeyError:
+            pass
 
     for keyword in counts:
         while True:
@@ -45,29 +43,44 @@ def select_keywords(counts):
             usr_rating = input('{}: '.format(keyword))
             if (usr_rating == chr(27)) | (usr_rating.lower() == 'c'):
                 # escape was pressed
-                return selected
+                return config
             elif usr_rating == "":
                 break
             else:
                 try:
-                    selected[keyword] = int(usr_rating)
+                    config.add_keyword(keyword, int(usr_rating))
                     break
                 except ValueError:
                     print('rating must be an integer.')
                     continue
-    return selected
-
-def selected2file(selected, filename='keywords.txt'):
-    """write the selected keywords to a file."""
-    with open(filename, 'w') as file:
-        file.write(json.dumps(selected))
+    return config
 
 
 def main():
-    les_mis_file = input('path to file: ')
-    counts = most_common_words_in_file(les_mis_file, 200, verbose=False)
-    selected = select_keywords(counts)
-    selected2file(selected)
+    parser = argparse.ArgumentParser("Extract keywords from arbitrary text files")
+    parser.add_argument("-c", "--config", help="Config file to write keywords to")
+    parser.add_argument("file", help="Text file to scan for keywords")
+    args = parser.parse_args()
+
+    config = Config()
+
+    if args.config:
+        configfile = args.config
+    else:
+        try:
+            configfile = find_configfile()
+        except FileNotFoundError:
+            configfile = Path.home() / ".scan_astro-ph.conf"
+    try:
+        config.read(configfile)
+    except FileNotFoundError:
+        pass
+
+    counts = most_common_words_in_file(args.file, 200)
+    select_keywords(config, counts)
+
+    print("Writing config back to {}".format(configfile))
+    config.write(configfile, overwrite=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR implements the format which replaces the separate `keywords.txt` and `authors.txt` as discussed in #8.
Closes #8 

### TODO:
- [x] Implement ini-style configuration using standard library `configparser`
- [x] Implement conversion from old configuration style
- [x] implement searching multiple paths for the config file
  - [x] locations on Unix
  - [x] locations on Windows
  - [x] locations on MacOS
- [x] Hook new implementation into `wordcounter`
- [x] Add options other than authors and keywords to file
- [x] Update README

## User facing changes:
There are now 4 more CLI arguments:
- `--config /path/to/configfile`: Load configfile from specified path
- `--default-config [/path/to/config]`: Write default config to `~/.scan_astro-ph.conf` / specified path
- `--config-convert [/path/to/new_config]`: convert `keywords.txt` and `authors.txt` to new format in `~/.scan_astro-ph.conf` / specified path
- `--edit`: Open config file in default text editor. If no config file exists, it asks if a new one should be created.

The config file paths are:
- Default location, where configs are written to when no argument is given on the arguments above.
  - on Linux / Unix (except MacOS): `$XDG_CONFIG_HOME/scan_astroph/scan_astroph.conf` (`XDG_CONFIG_HOME` defaults to `~/.config`)
  - on MacOS: `~/Library/Application Support/scan_astroph/scan_astroph.conf`
  - on Windows: `$HOME/Documents/scan_astroph/scan_astroph.conf`. Behaviour of `%APPDATA%` is weird on Windows (at least in Python from MS Store. Therefore, I put the config file into `~/Documents`, as many other programs are also using this for configuration files. Ugly, but what can you do.
- search path for config file is:
  -  `$SCAN_ASTRO_PH_CONF`
  - `~/.scan_astroph.conf`
  - default path described above

The new format is as discussed in INI-style, e.g.
```
[authors]
Alpher = 1
Bethe = 2
Gamov = 3

[keywords]
star = 1
planet = 2
habitable = 3

[options]
date = new
length = -1
minimum_rating = 6
reverse_list = False
show_resubmissions = False
show_cross_lists = True
```

`scan_astro-ph.wordcounter` has a new interface using argparse, it will update the config file it finds (using the above criteria), or will write a new one at `~/.scan_astro-ph.conf` (or the one specified on CLI).

### Implementation details.
The new implementation is a wrapper class `Config` around a `configparser.ConfigParser` object.
Properties are used to get an `dict[str, int]` output (as `configparser.ConfigParser` uses `str` internally).
Because the conversion is one way, there are extra methods to add new keywords and authors.